### PR TITLE
address Non-static method...should not be called statically error

### DIFF
--- a/pi.json_encode.php
+++ b/pi.json_encode.php
@@ -6,7 +6,7 @@
 		'pi_author' => 'Noble Studios',
 		'pi_author_url' => 'http://noblestudios.com/',
 		'pi_description' => 'Returns the input string in JSON encoded form.',
-		'pi_usage' => Json_encode::usage()
+		'pi_usage' => (new Json_encode)->usage()
 	);
 
 	class Json_encode {


### PR DESCRIPTION
I know this project is no longer maintained but I thought putting a PR together would be helpful if anyone else ran into this same problem.

The error message on `PHP 5.6.19` fires this type of error message:

`Non-static method...should not be called statically`

- if the method is not static we have to init before we can call it.
- This [stackoverflow answer][stack] shows the two ways to do this
  in PHP 5.4+

[stack]: http://stackoverflow.com/a/35995258/2344737