### PR TITLE
UTF-8 change (required for json_encode to work properly)

### DIFF
--- a/pi.json_encode.php
+++ b/pi.json_encode.php
@@ -16,7 +16,7 @@
 		public function __construct() {
 			$this->EE =& get_instance();
 			$options = ($this->EE->TMPL->fetch_param('options')) ? $this->EE->TMPL->fetch_param('options') : 0;
-			$this->return_data = json_encode($this->EE->TMPL->tagdata, $options);
+			$this->return_data = json_encode(utf8_encode($this->EE->TMPL->tagdata), $options);
 		}
 
 		function usage() {


### PR DESCRIPTION
This fixes the issue when non utf-8 strings are passed by converting them.

Other options may be to use the options param, but that doesn't seem to work as previously documented (as a string-passed all-caps, eg: "CONSTANT")